### PR TITLE
Python 2.6 compatibility

### DIFF
--- a/salmon/apps/monitor/management/commands/run_checks.py
+++ b/salmon/apps/monitor/management/commands/run_checks.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         """
         inactived_checks = models.Check.objects.exclude(active=False).exclude(
             pk__in=self.active_checks)
-        self.stdout.write("{} checks deactivated".format(
+        self.stdout.write("{0} checks deactivated".format(
             inactived_checks.count()))
         inactived_checks.update(active=False)
 
@@ -78,7 +78,7 @@ class Command(BaseCommand):
             target=target, function=func_name,
             name=func_opts.get('name', func_name),
             alert_emails=",".join(func_opts.get('alert_emails', [])))
-        self.stdout.write("+ {}".format(cmd))
+        self.stdout.write("+ {0}".format(cmd))
         timestamp = timezone.now()
         # shell out to salt command
         result = subprocess.check_output(cmd, shell=True)
@@ -98,13 +98,13 @@ class Command(BaseCommand):
         for name, raw_value in parsed.iteritems():
             if int(self.options["verbosity"]) > 1:
                 self.stdout.write(
-                    "+     name: {} -- str(raw_value): {}".format(
+                    "+     name: {0} -- str(raw_value): {1}".format(
                         name, str(raw_value)))
             value = utils.parse_value(raw_value, func_opts)
-            self.stdout.write("   {}: {}".format(name, value))
+            self.stdout.write("   {0}: {1}".format(name, value))
             minion, _ = models.Minion.objects.get_or_create(name=name)
             failed = utils.check_failed(value, func_opts)
-            self.stdout.write("   {}: {}".format("Assertion has failed",
+            self.stdout.write("   {0}: {1}".format("Assertion has failed",
                                                  failed))
             models.Result.objects.create(timestamp=timestamp,
                                          result=value,

--- a/salmon/apps/monitor/management/commands/run_checks.py
+++ b/salmon/apps/monitor/management/commands/run_checks.py
@@ -81,7 +81,8 @@ class Command(BaseCommand):
         self.stdout.write("+ {0}".format(cmd))
         timestamp = timezone.now()
         # shell out to salt command
-        result = subprocess.check_output(cmd, shell=True)
+        result = subprocess.Popen(cmd, shell=True,
+            stdout=subprocess.PIPE).communicate()[0]
 
         if not check.active:
             check.active = True

--- a/salmon/apps/monitor/models.py
+++ b/salmon/apps/monitor/models.py
@@ -24,7 +24,7 @@ class Check(models.Model):
     active = models.BooleanField(default=True)
 
     def __unicode__(self):
-        return '{} {} ({})'.format(self.target, self.function, self.name)
+        return '{0} {1} ({2})'.format(self.target, self.function, self.name)
 
     def send_alert_email(self):
         from_email = settings.DEFAULT_FROM_EMAIL
@@ -108,7 +108,7 @@ class Result(models.Model):
     @property
     def whisper_filename(self):
         """Build a file path to the Whisper database"""
-        return get_valid_filename("{}__{}.wsp".format(
+        return get_valid_filename("{0}__{1}.wsp".format(
             self.minion.name, self.check.name))
 
     def get_or_create_whisper(self):

--- a/salmon/apps/monitor/templatetags/monitor.py
+++ b/salmon/apps/monitor/templatetags/monitor.py
@@ -11,5 +11,5 @@ def display_result(result):
         template = 'boolean_field.html'
     else:
         template = 'default_field.html'
-    template = 'monitor/includes/{}'.format(template)
+    template = 'monitor/includes/{0}'.format(template)
     return {'field_template': template, 'result': result}

--- a/salmon/apps/monitor/utils.py
+++ b/salmon/apps/monitor/utils.py
@@ -16,17 +16,17 @@ def get_latest_results(minion=None, check_ids=None):
 
     if check_ids:
         if len(check_ids) == 1:
-            having = "check_id = {}".format(check_ids[0])
+            having = "check_id = {0}".format(check_ids[0])
         else:
-            having = "check_id IN {}".format(tuple(check_ids))
+            having = "check_id IN {0}".format(tuple(check_ids))
         if minion:
-            having += " AND minion_id={}".format(minion.pk)
+            having += " AND minion_id={0}".format(minion.pk)
         # we need a first query to get the latest batch of results
         latest_timestamps = cursor.execute("""
             SELECT minion_id, check_id, MAX("timestamp")
             FROM "monitor_result"
             GROUP BY "monitor_result"."minion_id", "monitor_result"."check_id"
-            HAVING {};""".format(having))
+            HAVING {0};""".format(having))
     if latest_timestamps:
         # transform the result to group them by minion_id, check_id, timestamp
         # the new form of latest_timestamps can easily be consumed by Result
@@ -79,7 +79,7 @@ class TypeTranslate(object):
         self.cast_to = cast_to
 
     def cast(self, value):
-        return getattr(self, 'to_{}'.format(self.cast_to))(value)
+        return getattr(self, 'to_{0}'.format(self.cast_to))(value)
 
     def to_boolean(self, value):
         return bool(value) == True


### PR DESCRIPTION
Currently, salmon only works with Python 2.7+. I was able to get it working on 2.6 with only minimal changes (as not much new stuff is in use). This is helpful for running on e.g. CentOS 6, for which higher versions are not easily available.
- Specify indices in format strings, e.g. `{0}` rather than `{}` (which is only supported [in 2.7 and later](http://docs.python.org/2/library/string.html#format-string-syntax)
- Use `subprocess.Popen` instead of `subprocess.check_output` (latter [added in 2.7](http://docs.python.org/2/library/subprocess.html#subprocess.check_output))
