### PR TITLE
New data type - raw_string

### DIFF
--- a/salmon/apps/monitor/models.py
+++ b/salmon/apps/monitor/models.py
@@ -128,6 +128,11 @@ class Result(models.Model):
             wsp = self.get_or_create_whisper()
             if isinstance(self.result, basestring) or self.result_type:
                 value = self.cleaned_result
+                if isinstance(value, basestring):
+                    if self.failed:
+                        value = 0
+                    else:
+                        value = 1
             else:
                 value = self.result
             wsp.update(self.timestamp, value)

--- a/salmon/apps/monitor/utils.py
+++ b/salmon/apps/monitor/utils.py
@@ -92,3 +92,6 @@ class TypeTranslate(object):
 
     def to_float(self, value):
         return float(value)
+
+    def to_raw_string(self, value):
+        return str(value)


### PR DESCRIPTION
Hi,
I added new useful data type for salmon checks - raw_string.
With this data type it's easy to check commands output and compare them with expected results.
I use this feature as http_check. For example:

``` yaml
'web*':
    cmd.run "curl -s -I http://localhost/|grep HTTP":
        name: "/ HTTP Code"
        type: raw_string
        assert: "'{value}' == 'HTTP/1.1 200 OK'"
```

I have couple of ideas for extending salmon user panel. I forked the project and I plan to send useful parts of code as pullrequests. 
