### PR TITLE
WIP: Workaround empty graph data.

### DIFF
--- a/salmon/core/graph.py
+++ b/salmon/core/graph.py
@@ -64,7 +64,12 @@ class WhisperDatabase(object):
         start_time, end_time, step = time_info
         current = start_time
         times = []
-        while current <= end_time:
+        while current <= end_time and len(times) <= len(values):
+            try:
+                if values[len(times)] is None:
+                    break
+            except IndexError:
+                pass
             times.append(current)
             current += step
         return zip(times, values)


### PR DESCRIPTION
zip will push empty values which end up being `null` in javascript and
breaking the graphs. This fixes it but need to investigate if it is
_correct_.
