### PR TITLE
Ensure source name does not cause NoReverseMatch exception

### DIFF
--- a/salmon/metrics/serializers.py
+++ b/salmon/metrics/serializers.py
@@ -1,4 +1,5 @@
 import logging
+from django.core.urlresolvers import reverse, NoReverseMatch
 from django.utils.timezone import now
 from rest_framework import serializers
 
@@ -16,6 +17,14 @@ class MetricSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Metric
         fields = ('source', 'name', 'value', 'timestamp')
+
+    def validate_source(self, attrs, source):
+        if source in attrs:
+            try:
+                reverse("history", args=[attrs[source]])
+            except NoReverseMatch:
+                raise serializers.ValidationError("Source is invalid.")
+        return attrs
 
     def restore_object(self, attrs, instance=None):
         kwargs = {'name': attrs['name']}

--- a/salmon/metrics/tests/test_serializers.py
+++ b/salmon/metrics/tests/test_serializers.py
@@ -36,3 +36,9 @@ class TestSerializer(TestCase):
                 'name': 'load'}
         serializer = MetricSerializer(data=data)
         self.assertFalse(serializer.is_valid())
+
+    def test_invalid_source(self):
+        data = {'source': 'test.example.com:8000',
+                'name': 'load', 'value': 0.1}
+        serializer = MetricSerializer(data=data)
+        self.assertFalse(serializer.is_valid())


### PR DESCRIPTION
Another option may be to allow ":" for the source name in case including port # in source
